### PR TITLE
Return error code with RuntimeException.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "laminas/laminas-cache": "^2.10",
         "laminas/laminas-cache-storage-adapter-test": "^1.0.2",
         "laminas/laminas-coding-standard": "~1.0.0",
-        "squizlabs/php_codesniffer": "^2.7"
+        "squizlabs/php_codesniffer": "^2.7",
+        "phpunit/phpunit": "^7.5.20"
     },
     "suggest": {
         "ext-memcached": "Memcached >= 1.0.0 to use the Memcached storage adapter"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccf968cfbde7a32230d70b43c6dd6aad",
+    "content-hash": "7e24818b3ec993c9b0ef5569cdd00bf8",
     "packages": [],
     "packages-dev": [
         {

--- a/src/Memcached.php
+++ b/src/Memcached.php
@@ -647,7 +647,10 @@ class Memcached extends AbstractAdapter implements
                 );
 
             default:
-                return new Exception\RuntimeException($this->getMemcachedResource()->getResultMessage());
+                return new Exception\RuntimeException(
+                    $this->getMemcachedResource()->getResultMessage(),
+                    $code
+                );
         }
     }
 }

--- a/src/Memcached.php
+++ b/src/Memcached.php
@@ -160,7 +160,7 @@ class Memcached extends AbstractAdapter implements
         $memc  = $this->getMemcachedResource();
         $stats = $memc->getStats();
         if ($stats === false) {
-            throw new Exception\RuntimeException($memc->getResultMessage());
+            throw new Exception\RuntimeException($memc->getResultMessage(), $memc->getResultCode());
         }
 
         $mem = array_pop($stats);
@@ -179,7 +179,7 @@ class Memcached extends AbstractAdapter implements
         $memc  = $this->getMemcachedResource();
         $stats = $memc->getStats();
         if ($stats === false) {
-            throw new Exception\RuntimeException($memc->getResultMessage());
+            throw new Exception\RuntimeException($memc->getResultMessage(), $memc->getResultCode());
         }
 
         $mem = array_pop($stats);

--- a/test/unit/MemcachedTest.php
+++ b/test/unit/MemcachedTest.php
@@ -10,6 +10,7 @@ namespace LaminasTest\Cache\Storage\Adapter;
 
 use Laminas\Cache;
 use Prophecy\Argument;
+use RuntimeException;
 
 /**
  * @group      Laminas_Cache
@@ -228,6 +229,28 @@ class MemcachedTest extends CommonAdapterTest
 
         $this->assertSame('testPersistentId', $resourceManager->getPersistentId($resourceId));
         $this->assertSame('testPersistentId', $options->getPersistentId());
+    }
+
+    public function testExceptionCodeIsPassedToRuntimeException(): void
+    {
+        $memcached = new Cache\Storage\Adapter\Memcached(
+            new Cache\Storage\Adapter\MemcachedOptions(
+                [
+                    'servers' => ['foobar'],
+                ]
+            )
+        );
+
+        try {
+            $memcached->flush();
+        } catch (RuntimeException $exception) {
+            self::assertIsInt($exception->getCode());
+            self::assertGreaterThan(0, $exception->getCode());
+            self::assertInstanceOf(Cache\Exception\RuntimeException::class, $exception);
+            return;
+        }
+
+        self::fail('Flush should have thrown an exception.');
     }
 
     public function tearDown()


### PR DESCRIPTION
This brings parity with other storage adapters that already include the error code in exceptions.

Signed-off-by: Ere Maijala <ere.maijala@helsinki.fi>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no
